### PR TITLE
cipher/rekey: fix Cipher REKEY operation

### DIFF
--- a/dissononce/cipher/cipher.py
+++ b/dissononce/cipher/cipher.py
@@ -46,4 +46,4 @@ class Cipher(object):
         :return:
         :rtype: bytes
         '''
-        return self.encrypt(key, 2**64 - 1, b"", bytes([0] * 32))
+        return self.encrypt(key, 2**64 - 1, b"", bytes([0] * 32))[:32]

--- a/dissononce/processing/impl/cipherstate.py
+++ b/dissononce/processing/impl/cipherstate.py
@@ -32,7 +32,7 @@ class CipherState(object):
         self._nonce = nonce
 
     def rekey(self):
-        self.initialize_key(self._cipher.rekey(self._key))
+        self._key = self._cipher.rekey(self._key)
 
     def encrypt_with_ad(self, ad, plaintext):
         """


### PR DESCRIPTION
As per the Noise Protocol specification, the default REKEY should use the
first 32 bytes returned by ENCRYPT acting on 32 bytes of zeros with the
current key, a reserved nonce, and no associated data.

The implementation here was rekeying with the encrypted result plus the
authentication data, causing Cipher to fail on the next encrypt/decrypt call
due to an invalid key length.

This change clamps the rekey to the ciphertext sans the authentication data.

Signed-off-by: Derrick Pallas <derrick@pallas.us>